### PR TITLE
Several updates and additions to Charaxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -12552,8 +12552,13 @@ c	tovaria
 k	forseri
 k	tovaria
 g	Perrhybris
+a	lorena
+a	lypera
+e	Yellow-banded White
+d	Gelbbindiger Weißling
 a	pamela
 e	Pamela
+e	Dimorphic White
 d	Pamela
 s	pyrrha
 g	Phulia
@@ -16001,10 +16006,12 @@ n	Drury, 1773
 s2	Cynthia
 i	Paranartia
 a	dimorphica
+e	Northern Short-tailed Admiral
 e	Dimorphic Admiral
 d	Afrikanischer Admiral
 s2	Antanartia
 a	hippomene
+e	Southern Short-tailed Admiral
 e	Cape Admiral
 d	Kap-Admiral
 s2	Antanartia
@@ -20540,9 +20547,14 @@ a	conspicua
 a	nina
 e	Tiny Sailor
 d	Zwergmatrose
-a	nysiades
+c	nysiades
 e	Variable Sailor
 d	Variabler Matrose
+k	amieti
+k	continuata
+k	dentifera
+k	mpassae
+k	nysiades
 a	puella
 e	Little Sailor
 d	Kleiner Matrose
@@ -27273,6 +27285,8 @@ d2	Blattflügler
 t	Charaxini
 e2	Charaxes
 d2	Charaxes
+sh	Euxanthini
+sh	Pallini
 g	Charaxes
 r	Aduse-Poku, 2009
 l	Out-of-Africa again: A phylogenetic hypothesis of the genus Charaxes (Lepidoptera: Nymphalidae) based on five gene regions
@@ -27285,6 +27299,91 @@ d	Acräen-Charaxes
 a	fournierae
 e	Euphaedra Charaxes
 d	Förster-Charaxes
+o	Bernardus
+r	Müller, 2010
+l	‘After Africa’: the evolutionary history and systematics of the genus Charaxes Ochsenheimer (Lepidoptera: Nymphalidae) in the Indo-Pacific region
+p	10.1111/j.1095-8312.2010.01426.x
+a	antonius
+c	bernardus
+e	Tawny Rajah
+e	Yellow Rajah
+d	Oranger Radscha
+b	Papilio
+n	Fabricius, 1793
+z	Haridra
+n	Moore, 1880
+s	bajula basilisae
+s	borneensis bupalus
+s	harmodius shiloi
+s	polyxena
+s	psaphon imna
+k	ajax
+k	aristogiton
+k	bajula
+k	baya
+k	basilisae
+k	bernardus
+k	borneensis
+k	bupalus
+k	fervens
+k	hemana
+k	hierax
+k	imna
+k	marmax
+k	plateni
+k	psaphon
+k	repetitus
+c	distanti
+e	Malay Rajah
+d	Malaiischer Radscha
+k	distanti
+k	harmodius
+k	harpagon
+k	thespius
+a	durnfordi
+e	Chestnut Rajah
+d	Brauner Radscha
+a	elwesi
+e	Elwes' Rajah
+d	Elwes' Radscha
+a	eurialus
+e	Painted Rajah
+d	Bunter Radscha
+a	kahruba
+e	Variegated Rajah
+d	Gescheckter Radscha
+c	latona
+e	Orange Emperor
+d	Oranger Charaxes
+k	affinis
+k	latona
+k	musashi
+a	madensis
+s3	mars
+a	marki
+a	mars
+e	Iron Rajah
+d	Eiserner Radscha
+a	nitebis
+e	Green Rajah
+d	Grüner Radscha
+a	ocellatus
+a	orilus
+a	sangana
+a	setan
+e	Velvet Rajah
+d	Samtschwarzer Radscha
+o	Candiope
+a	antamboulou
+a	candiope
+e	Green-veined Emperor
+e	Green-veined Charaxes
+d	Grünader-Charaxes
+s	thomasius
+s	velox
+u	thomasius
+u	velox
+a	cowani
 o	Jasius
 a	ansorgei
 e	Ansorge's Charaxes
@@ -27351,7 +27450,6 @@ s	jasius harrisoni
 s3	jasius
 u	harrisoni
 o	Nobilis
-a	lydiae
 a	nobilis
 e	Noble White Charaxes
 a	superbus
@@ -27398,65 +27496,6 @@ a	xiphares
 e	Forest King Emperor
 e	Forest King Charaxes
 d	Blauer Waldkönig
-i	Haridra
-o	Bernardus
-c	bernardus
-e	Tawny Rajah
-e	Yellow Rajah
-e	Orange Emperor
-d	Oranger Radscha
-s	polyxena
-s	psaphon imna
-k	affinis
-k	aristogiton
-k	bajula
-k	fervens
-k	harmodius
-k	hierax
-k	imna
-k	latona
-k	marmax
-k	musashi
-k	psaphon
-k	repetitus
-a	borneensis
-s	bupalus
-u	bupalus
-a	distanti
-e	Malay Rajah
-d	Malaiischer Radscha
-a	durnfordi
-e	Chestnut Rajah
-d	Brauner Radscha
-a	elwesi
-a	eurialus
-a	kahruba
-e	Variegated Rajah
-d	Variabler Radscha
-a	marki
-a	mars
-e	Iron Rajah
-d	Eiserner Radscha
-s	madensis
-u	madensis
-a	nitebis
-e	Green Rajah
-d	Grüner Radscha
-a	ocellatus
-a	orilus
-a	plateni
-a	setan
-o	Candiope
-a	antamboulou
-a	candiope
-e	Green-veined Emperor
-e	Green-veined Charaxes
-d	Grünader-Charaxes
-s	thomasius
-s	velox
-u	thomasius
-u	velox
-a	cowani
 i	Stonehamia
 o	Analava
 a	analava
@@ -27474,6 +27513,10 @@ a	varanes
 e	Pearl Charaxes
 e	Pearl Emperor
 d	Perle
+b	Papilio
+n	Cramer, 1764
+z	Stonehamia
+n	Cowan, 1968
 s	bertrami
 s	defulvata
 u	bertrami
@@ -27506,150 +27549,380 @@ i	Zingha
 a	zingha
 e	Shining Red Charaxes
 d	Feuerroter Waldkönig
+b	Papilio
+n	Stoll, 1780
+z	Zingha
+n	Hemming, 1939
+i	Euxanthe
+a	crossleyi
+e	Crossley's Forest Queen
+d	Crossley's Waldkönigin
+s2	Euxanthe
+a	eurinome
+e	Northern Forest Queen
+d	Nördliche Waldkönigin
+b	Papilio
+n	Cramer, 1775
+z	Anthora
+n	Doubleday, 1844
+z	Euxanthe
+n	Hübner, 1819
+s2	Euxanthe
+a	madagascariensis
+e	Madagascan Forest Queen
+d	Madagassische Waldkönigin
+b	Godartia
+n	Lucas, 1843
+z	Godartia
+n	Lucas, 1843
+s2	Euxanthe
+a	tiberius
+e	Red Forest Queen
+d	Rote Waldkönigin
+s2	Euxanthe
+a	trajanus
+e	Trajan's Forest Queen
+d	Trajans Waldkönigin
+s2	Euxanthe
+a	wakefieldi
+e	Southern Forest Queen
+d	Südliche Waldkönigin
+s2	Euxanthe
+s4	Euxanthe wakefieldii
+i	Laodice
+a	doubledayi
+e	Doubleday's Untailed Charaxes
+d	Doubleday's Charaxes
+s2	Laodice
+a	lycurgus
+e	Laodice Untailed Charaxes
+d	Ungeschwänzter Charaxes
+b	Papilio
+n	Fabricius, 1793
+z	Laodice
+n	Bouyer, 2023
+s	laodice
+s2	Laodice
+a	mycerina
+s2	Laodice
+a	porthos
+e	Porthos Untailed Charaxes
+d	Porthos-Charaxes
+s2	Laodice
+a	zelica
+s2	Laodice
 i	Eriboea
 o	Anticlea
 a	anticlea
 e	Small Flame-bordered Charaxes
 d	Kleiner Flammen-Charaxes
+b	Papilio
+n	Drury, 1782
+s2	Eriboea
 a	baumanni
 e	Little Charaxes
 d	Zwergcharaxes
+b	Charaxes
+n	Rogenhofer, 1891
+s2	Eriboea
 a	opinatus
+b	Charaxes
+n	Heron, 1909
+s2	Eriboea
 o	Etesipe
 a	achaemenes
 e	Bushveld Emperor
 e	Bush Charaxes
 d	Busch-Charaxes
-a	etesipe
+s2	Eriboea
+c	etesipe
 e	Savannah Charaxes
 e	Scarce Forest Emperor
 d	Savannen-Charaxes
+b	Nymphalis etesipe
+n	Godart, 1824
+s4	Eriboea cacuthis
+s2	Eriboea
+s4	Eriboea etesipe pemba
+s4	Eriboea etesipe tavetensis
+s4	Eriboea paradoxa
+s4	Eriboea penricei
+s4	Eriboea viossati
+k	cacuthis
+k	etesipe
+k	paradoxa
+k	pemba
+k	penricei
+k	tavetensis
+k	viossati
+a	taverniersi
+s2	Eriboea
+a	thysi
+s2	Eriboea
 o	Etheocles
+a	blanda
+s2	Eriboea
 c	cedreatis
 e	Green Demon Charaxes
 e	Dusky Charaxes
 d	Grünschimmernder Charaxes
+b	Charaxes
+n	Hewitson, 1874
 s	cendreatis
-s	chintechi pseudophaeus
-s	dewitzi
 s3	etheocles
-s	manica chittyi
-s	viola diversiforma
-s	viola phaeus
-s	viola variata
+s2	Eriboea
+s4	Eriboea chepalungu
+s4	Eriboea prettejohni
 k	cedreatis
-k	chintechi
-k	chittyi
-k	diversiforma
-k	fionae
-k	fulgurata
-k	howarthi
-k	manica
-k	phaeus
-k	pseudophaeus
-k	variata
-k	williami
+k	chepalungu
+k	prettejohni
+a	contrarius
+s2	Eriboea
 c	ethalion
 e	Satyr Charaxes
 d	Satyr-Charaxes
-s	alpinus nyikensis
+b	Nymphalis
+n	Boisduval, 1847
+s	chintechi pseudophaeus
+s	kirki daria
+s	kirki suk
+s	manica chittyi
+s	viola brainei
+s	viola diversiforma
+s	viola phaeus
+s	viola variata
+s	virilis lenis
+s4	Eriboea alpinus
+s4	Eriboea aubyni
+s4	Eriboea baileyi
+s4	Eriboea berkeleyi
+s4	Eriboea bernstorffi
+s4	Eriboea bocqueti
+s4	Eriboea brainei
+s4	Eriboea catachrous
+s4	Eriboea chintechi
+s4	Eriboea chintechi pseudophaeus
+s4	Eriboea dewitzi
+s4	Eriboea diversiforma
+s2	Eriboea
+s4	Eriboea ethalion binghami
+s4	Eriboea fionae
+s4	Eriboea fulgurata
+s4	Eriboea galawadiwosi
+s4	Eriboea gerdae
+s4	Eriboea grahamei
+s4	Eriboea howarthi
+s4	Eriboea kirki
+s4	Eriboea kirki daria
+s4	Eriboea kirki suk
+s4	Eriboea mafuga
+s4	Eriboea manica
+s4	Eriboea manica chittyi
+s4	Eriboea phaeus
+s4	Eriboea plantroui
+s4	Eriboea pondoensis
+s4	Eriboea sidamo
+s4	Eriboea turlini
+s4	Eriboea vansoni
+s4	Eriboea variata
+s4	Eriboea viola
+s4	Eriboea virilis
+s4	Eriboea virilis lenis
+s4	Eriboea williami
+s4	Eriboea zambeziensis
 k	alpinus
+k	aubyni
 k	baileyi
+k	berkeleyi
+k	bernstorffi
 k	binghami
-k	chepalungu
-k	chunguensis
-k	congdoni
-k	dreuxi
+k	bocqueti
+k	brainei
+k	catachrous
+k	chintechi
+k	chittyi
+k	daria
+k	dewitzi
+k	diversiforma
 k	ethalion
+k	fionae
+k	fulgurata
 k	galawadiwosi
-k	iringae
-k	karkloof
+k	gerdae
+k	grahamei
+k	howarthi
+k	kirki
+k	lenis
 k	mafuga
-k	margaretae
-k	marieps
-k	mccleeryi
-k	nyikensis
-k	pondo
+k	manica
+k	phaeus
+k	plantroui
+k	pondoensis
+k	pseudophaeus
+k	sidamo
+k	suk
 k	tulini
+k	vansoni
+k	variata
+k	viola
+k	virilis
+k	williami
+k	zambeziensis
 c	etheocles
 e	Demon Charaxes
 e	Black Charaxes
 d	Schwarzer Charaxes
+b	Papilio
+n	Cramer, 1777
+z	Eriboea
+n	Hübner, 1819
 s	angelae
-s	viola brainei
-s	virilis lenis
-k	aubyni
-k	basquini
-k	berkeleyi
-k	bocqueti
-k	brainei
+s4	Eriboea angelae
+s4	Eriboea chevroti
+s2	Eriboea
+s4	Eriboea etheocles carpenteri
+s4	Eriboea etheocles evansi
+s4	Eriboea ochracea
+s4	Eriboea petersi
 k	carpenteri
-k	catachrous
 k	chevroti
-k	contrarius
+k	etheocles
 k	evansi
-k	grahamei
-k	lenis
 k	ochracea
-k	pembanus
 k	petersi
-k	plantroui
-k	sidamo
-k	usambarae
-k	vansoni
-k	virilis
-a	gallagheri
+c	gallagheri
 e	Gallagher's Charaxes
 d	Gallagher's Charaxes
+b	Charaxes
+n	Van Son, 1962
+s2	Eriboea
+s4	Eriboea martini
+s4	Eriboea mtuiae
+s4	Eriboea mutinondoensis
+k	gallagheri
+k	martini
+k	mtuiae
+k	mutinondoensis
+r	Mtui, 2017
+l	Phylogenetic relationships, distribution and abundance of Charaxes mtuiae Collins Congdon and Bampton, 2017 (Papilionoidea: Nymphalidae: Charaxinae) and its host plant in the Udzungwa mountain forest in southern Tanzania
+p	10.4314/met.v32i1.12
 a	guderiana
 e	Blue-spangled Emperor
 e	Blue-spangled Charaxes
 e	Guderian's Charaxes
 d	Gudarian's Charaxes
+s2	Eriboea
+a	karkloof
+e	Two-dot Black Charaxes
+d	Südafrikanischer Schwarzer Charaxes
+b	Charaxes
+n	Van Someren & Jackson, 1957
+s	marieps
+s2	Eriboea
+s4	Eriboea marieps
+u	marieps
 a	kheili
 s	northcotti
+s2	Eriboea
+s4	Eriboea kheili northcotti
 u	northcotti
-a	martini
-c	viola
-e	Savanna Demon Charaxes
-d	Savannenkönig
-s	kirki daria
-s	kirki suk
-k	bernstorffi
-k	chanleri
-k	daria
-k	figini
-k	kirki
-k	suk
+c	pembanus
+e	Tanzanian Black Charaxes
+e	Cryptic Black Demon
+d	Kryptischer Schwarzer Charaxes
+b	Charaxes
+n	Jordan, 1925
+s	alpinus nyikensis
+s3	etheocles
+s4	Eriboea chunguensis
+s4	Eriboea congdoni
+s4	Eriboea margaretae
+s4	Eriboea mccleeryi
+s4	Eriboea mccleeryi iringae
+s4	Eriboea nyikensis
+s2	Eriboea
+s4	Eriboea usambarae
+k	chunguensis
+k	congdoni
+k	iringae
+k	margaretae
+k	mccleeryi
+k	nyikensis
+k	pembanus
+k	usambarae
 o	Hildebrandti
 a	hildebrandti
 e	Hildebrandt's Charaxes
 d	Hildebrandt's Charaxes
+b	Nymphalis
+n	Dewitz, 1879
+s2	Eriboea
 o	Jahlusa
 a	jahlusa
 e	Pearl-spotted Emperor
 e	Pearl-spotted Charaxes
 d	Perlenfleck-Charaxes
+b	Nymphalis
+n	Trimen, 1862
+s2	Eriboea
 o	Solon
-a	solon
+c	solon
 e	Black Rajah
 d	Schwarzer Radscha
+b	Papilio
+n	Fabricius, 1793
+s4	Eriboea echo
+s4	Eriboea hannibal
+s4	Eriboea lampedo
+s2	Eriboea
+k	echo
+k	hannibal
+k	lampedo
+k	solon
+r	Toussaint, 2019
+l	Biogeographical, molecular and morphological evidence unveils cryptic diversity in the Oriental black rajah Charaxes solon (Fabricius, 1793) (Lepidoptera: Nymphalidae: Charaxinae)
+p	10.1093/biolinnean/bly169
 i	Viridixes
 a	eupale
 e	Common Green Charaxes
 d	Grüner Charaxes
+b	Papilio eupale
+n	Drury, 1782
+z	Viridixes
+n	Bouyer & Vingerhoedt, 2008
 s	dilutus
-s	dilutus montis
 s	eupalus
+s4	Viridixes dilutus
+s2	Viridixes
 u	dilutus
-u	montis
+a	montis
+e	Falcate Green Charaxes
+d	Grüner Spitzflügel-Charaxes
+s	dilutus montis
+s	eupale montis
+s4	Viridixes montis
+a	schiltzei
+b	Charaxes
+n	Bouyer, 1991
+s2	Viridixes
+a	schultzei
+e	Light Green Charaxes
+d	Hellgrüner Charaxes
+b	Charaxes
+n	Röber, 1936
+s2	Viridixes
 a	subornatus
 e	Ornate Green Charaxes
 e	Minor Green Charaxes
 d	Kleiner Grüner Charaxes
 s	minor
+s4	Viridixes minor
+s2	Viridixes
 u	minor
 i	Polyura
+r	Toussaint, 2015
+l	Comparative molecular species delimitation in the charismatic Nawab butterflies (Nymphalidae, Charaxinae, Polyura)
+p	10.1016/j.ympev.2015.05.015
 o	Athamas
 r2	Toussaint, 2019
 l	New Insights into the Systematics of the Genus Polyura Billberg, 1820 (Nymphalidae, Charaxinae) with an Emphasis on the P. athamas Group
@@ -27657,16 +27930,19 @@ p	10.18473/lepi.70i2.a10
 c	athamas
 e	Common Nawab
 d	Gewöhnlicher Nawab
+b	Papilio
+n	Drury, 1773
 s4	Polyura agraria
 s4	Polyura agrarius
 s4	Polyura alphius
 s4	Polyura arja
 s2	Polyura
+s4	Polyura athamas uraeus
 s4	Polyura attalus
+s4	Polyura attalus uraeus
 s4	Polyura bharata
 s4	Polyura chersonesus
 s4	Polyura hebe
-s4	Polyura moori
 s4	Polyura paulettae
 k	agrarius
 k	alphius
@@ -27676,18 +27952,26 @@ k	attalus
 k	bharata
 k	chersonesus
 k	hebe
-k	moori
 k	paulettae
+k	uraeus
 a	jalysus
 e	Indian Yellow Nawab
 d	Gelblichgrüner Nawab
 s2	Polyura
+a	moori
+e	Malayan Nawab
+d	Malaiischer Nawab
+s2	Polyura
 a	schreiber
 e	Blue Nawab
 d	Blauer Nawab
+s	luzonica
+s	luzonicus
+s4	Polyura luzonica
 s4	Polyura luzonicus
 s2	Polyura
 u	luzonicus
+u	schreiber
 o	Eudamippus
 a	delphis
 e	White Nawab
@@ -27727,8 +28011,17 @@ a	pleione
 e	Square-winged Red Charaxes
 e	Leafwing Charaxes
 d	Blattflügel-Charaxes
+b	Nymphalis
+n	Godart, 1824
 s2	Polyura
 o	Pyrrhus
+a	attila
+e	Solomon Nawab
+d	Salomonen-Nawab
+s3	jupiter
+s2	Polyura
+s4	Polyura jupiter attila
+s4	Polyura pyrrhus attila
 a	caphontis
 e	Fijian Emperor
 d	Fdischi-Charaxes
@@ -27753,89 +28046,67 @@ a	gamma
 s2	Polyura
 a	inopinatus
 s2	Polyura
-a	jupiter
-e	Papuan Nawab
-d	Papua-Nawab
-s2	Polyura
 a	pyrrhus
 e	Tailed Nawab
 e	Tailed Emperor
 d	Australischer Nawab
+d	Australischer Charaxes
 b	Papilio
 n	Linnaeus, 1758
+z	Polyura
+n	Billberg, 1820
+s	andrewsi
+s	gilolensis
+s	jupiter
 s	sempronius
+s	smilesi
+s4	Polyura andrewsi
 s4	Polyura galaxia
 s4	Polyura gilolensis
-s4	Polyura gilolensis buruana
-s4	Polyura gilolensis obiensis
+s4	Polyura jupiter
 s2	Polyura
 s4	Polyura sempronius
-u	buruana
-u	galaxia
+s4	Polyura smilesi
+u	andrewsi
 u	gilolensis
-u	obiensis
+u	jupiter
 u	sempronius
+u	smilesi
 a	sacco
-s2	Polyura
-a	smilesi
 s2	Polyura
 o	Zoolina
 a	kahldeni
 e	African Nawab
 d	Afrikanischer Nawab
+s2	Polyura
 a	zoolina
 e	Club-tailed Emperor
 e	Club-tailed Charaxes
 d	Keulenschwanz-Charaxes
+b	Nymphalis
+n	Westwood, 1850
 s	betsimisaraka
 s4	Polyura betsimisaraka
 s4	Polyura ehmckei
+s2	Polyura
 u	betsimisaraka
 u	ehmckei
-i	Euxanthe
-o	Eurinome
-a	crossleyi
-e	Crossley's Forest Queen
-d	Crossley's Waldkönigin
-s2	Euxanthe
-a	eurinome
-e	Northern Forest Queen
-d	Nördliche Waldkönigin
-s2	Euxanthe
-a	madagascariensis
-e	Madagascan Forest Queen
-d	Madagassische Waldkönigin
-s2	Euxanthe
-a	tiberius
-e	Red Forest Queen
-d	Rote Waldkönigin
-s2	Euxanthe
-a	trajanus
-e	Trajan's Forest Queen
-d	Trajans Waldkönigin
-s2	Euxanthe
-a	wakefieldi
-e	Southern Forest Queen
-d	Südliche Waldkönigin
-s2	Euxanthe
-s4	Euxanthe wakefieldii
-o	Lycurgus
-a	doubledayi
-e	Doubleday's Untailed Charaxes
-d	Doubleday's Charaxes
-a	lycurgus
-e	Laodice Untailed Charaxes
-d	Ungeschwänzter Charaxes
-s	laodice
-a	mycerina
-a	porthos
-e	Porthos Untailed Charaxes
-d	Porthos-Charaxes
-a	zelica
-i	Nichetes
+i	Ydeali
+a	lydiae
+b	Charaxes
+n	Holland, 1917
+z	Ydeali
+n	Bouyer, 2023
+s2	Ydeali
+i	Setechin
 a	nichetes
 e	Manx Charaxes
 d	Manx-Charaxes
+b	Charaxes
+n	Grose-Smith, 1883
+z	Setechin
+n	Bouyer, 2023
+s2	Setechin
 g	Palla
 a	decius
 e	White-banded Palla
@@ -37780,12 +38051,17 @@ e	Great Brownie
 d	Großer Lausfalter
 j	Megalopalpina
 g	Megalopalpus
+a	metaleucus
+e	Large Harvester
 a	simplex
+a	zyma
+e	Common Harvester
+d	Zikadenfalter
 t	Spalgini
 j	Spalgina
 g	Feniseca
 a	tarquinius
-e	Harvester
+e	American Harvester
 d	Amerikanischer Lausfalter
 g	Spalgus
 a	epius
@@ -71719,6 +71995,9 @@ d	Amerikanisches Jungfernkind
 a	parthenias
 e	Orange Underwing
 d	Birken-Jungfernkind
+d	Großes Jungfernkind
+b	Phalaena
+n	Linnaeus, 1761
 g	Boudinotiana
 a	notha
 e	Light Orange Underwing
@@ -79641,6 +79920,7 @@ k	naessigi
 k	naumanni
 k	pryeri
 k	ricini
+k	vesta
 k	wangi
 k	yayukae
 o	Insularis


### PR DESCRIPTION
I will not accept the proposal of Bouyer, 2023, to split Charaxes into eight separate genera, this is a typical case of unnecessary oversplitting based on COI barcodes. The approach of Aduse-Poku et al., 2009 still stands well until proper phylogenomic data become available. Splitting Charaxes into so many genera just to keep Euxanthe and Polyura valid, as implied, is also questionable. The suggested new genera + Euxanthe + Polyura appear no more separated from each other than one would expect from other typical subgenera, in comparison to much more isolated "true" genera of Charaxinae like Palla, Prepona, Prothoe or Anaea. Did the following changes and additions to the data for now:
- Added the new genera as synonyms to at least make the proposed names available via search.
- Merged subgenus Haridra into subgenus Charaxes, due to it being clearly nested in there according to Aduse-Poku et al., 2009
- Separated Lycurgus Group from subgenus Euxanthe to form a separate subgenus "Laodice" due to its long, not clearly placed branch in both Aduse-Poku et al., 2009 and Bouyer, 2023.
- Accepted Charaxes lydiae being its own, completely isolated subgenus "Ydeali"
- Changed invalid subgenus name "Nichetes" to the now valid name "Setechin"
- Countless minor updates, additions and reclassifications of species/subspecies/microspecies. Species delimitation is still rather unclear and arbitrary in some places, especially within subgenera Eriboea and Polyura.